### PR TITLE
Modify the counter data format so the general counters are an array s…

### DIFF
--- a/Intel/AlderLake.cs
+++ b/Intel/AlderLake.cs
@@ -554,7 +554,7 @@ namespace PmcReader.Intel
             public MonitoringUpdateResults Update()
             {
                 MonitoringUpdateResults results = new MonitoringUpdateResults();
-                results.unitMetrics = new string[cpu.pCores.Count][];
+                results.unitMetrics = new string[cpu.pCores.Count + cpu.eCores.Count][];
                 cpu.InitializeCoreTotals();
                 for (int threadIdx = 0; threadIdx < cpu.GetThreadCount(); threadIdx++)
                 {

--- a/Intel/AlderLake.cs
+++ b/Intel/AlderLake.cs
@@ -139,26 +139,26 @@ namespace PmcReader.Intel
                 NormalizedThreadCounts[threadIdx].activeCycles = activeCycles * normalizationFactor;
                 NormalizedThreadCounts[threadIdx].instr = retiredInstructions * normalizationFactor;
                 NormalizedThreadCounts[threadIdx].refTsc = refTsc * normalizationFactor;
-                NormalizedThreadCounts[threadIdx].pmc0 = pmc0 * normalizationFactor;
-                NormalizedThreadCounts[threadIdx].pmc1 = pmc1 * normalizationFactor;
-                NormalizedThreadCounts[threadIdx].pmc2 = pmc2 * normalizationFactor;
-                NormalizedThreadCounts[threadIdx].pmc3 = pmc3 * normalizationFactor;
-                NormalizedThreadCounts[threadIdx].pmc4 = pmc4 * normalizationFactor;
-                NormalizedThreadCounts[threadIdx].pmc5 = pmc5 * normalizationFactor;
-                NormalizedThreadCounts[threadIdx].pmc6 = pmc6 * normalizationFactor;
-                NormalizedThreadCounts[threadIdx].pmc7 = pmc7 * normalizationFactor;
+                NormalizedThreadCounts[threadIdx].pmc[0] = pmc0 * normalizationFactor;
+                NormalizedThreadCounts[threadIdx].pmc[1] = pmc1 * normalizationFactor;
+                NormalizedThreadCounts[threadIdx].pmc[2] = pmc2 * normalizationFactor;
+                NormalizedThreadCounts[threadIdx].pmc[3] = pmc3 * normalizationFactor;
+                NormalizedThreadCounts[threadIdx].pmc[4] = pmc4 * normalizationFactor;
+                NormalizedThreadCounts[threadIdx].pmc[5] = pmc5 * normalizationFactor;
+                NormalizedThreadCounts[threadIdx].pmc[6] = pmc6 * normalizationFactor;
+                NormalizedThreadCounts[threadIdx].pmc[7] = pmc7 * normalizationFactor;
                 NormalizedThreadCounts[threadIdx].NormalizationFactor = normalizationFactor;
                 NormalizedTotalCounts.activeCycles += NormalizedThreadCounts[threadIdx].activeCycles;
                 NormalizedTotalCounts.instr += NormalizedThreadCounts[threadIdx].instr;
                 NormalizedTotalCounts.refTsc += NormalizedThreadCounts[threadIdx].refTsc;
-                NormalizedTotalCounts.pmc0 += NormalizedThreadCounts[threadIdx].pmc0;
-                NormalizedTotalCounts.pmc1 += NormalizedThreadCounts[threadIdx].pmc1;
-                NormalizedTotalCounts.pmc2 += NormalizedThreadCounts[threadIdx].pmc2;
-                NormalizedTotalCounts.pmc3 += NormalizedThreadCounts[threadIdx].pmc3;
-                NormalizedTotalCounts.pmc4 += NormalizedThreadCounts[threadIdx].pmc4;
-                NormalizedTotalCounts.pmc5 += NormalizedThreadCounts[threadIdx].pmc5;
-                NormalizedTotalCounts.pmc6 += NormalizedThreadCounts[threadIdx].pmc6;
-                NormalizedTotalCounts.pmc7 += NormalizedThreadCounts[threadIdx].pmc7;
+                NormalizedTotalCounts.pmc[0] += NormalizedThreadCounts[threadIdx].pmc[0];
+                NormalizedTotalCounts.pmc[1] += NormalizedThreadCounts[threadIdx].pmc[1];
+                NormalizedTotalCounts.pmc[2] += NormalizedThreadCounts[threadIdx].pmc[2];
+                NormalizedTotalCounts.pmc[3] += NormalizedThreadCounts[threadIdx].pmc[3];
+                NormalizedTotalCounts.pmc[4] += NormalizedThreadCounts[threadIdx].pmc[4];
+                NormalizedTotalCounts.pmc[5] += NormalizedThreadCounts[threadIdx].pmc[5];
+                NormalizedTotalCounts.pmc[6] += NormalizedThreadCounts[threadIdx].pmc[6];
+                NormalizedTotalCounts.pmc[7] += NormalizedThreadCounts[threadIdx].pmc[7];
             }
         }
 
@@ -193,22 +193,22 @@ namespace PmcReader.Intel
                 NormalizedThreadCounts[threadIdx].activeCycles = activeCycles * normalizationFactor;
                 NormalizedThreadCounts[threadIdx].instr = retiredInstructions * normalizationFactor;
                 NormalizedThreadCounts[threadIdx].refTsc = refTsc * normalizationFactor;
-                NormalizedThreadCounts[threadIdx].pmc0 = pmc0 * normalizationFactor;
-                NormalizedThreadCounts[threadIdx].pmc1 = pmc1 * normalizationFactor;
-                NormalizedThreadCounts[threadIdx].pmc2 = pmc2 * normalizationFactor;
-                NormalizedThreadCounts[threadIdx].pmc3 = pmc3 * normalizationFactor;
-                NormalizedThreadCounts[threadIdx].pmc4 = pmc4 * normalizationFactor;
-                NormalizedThreadCounts[threadIdx].pmc5 = pmc5 * normalizationFactor;
+                NormalizedThreadCounts[threadIdx].pmc[0] = pmc0 * normalizationFactor;
+                NormalizedThreadCounts[threadIdx].pmc[1] = pmc1 * normalizationFactor;
+                NormalizedThreadCounts[threadIdx].pmc[2] = pmc2 * normalizationFactor;
+                NormalizedThreadCounts[threadIdx].pmc[3] = pmc3 * normalizationFactor;
+                NormalizedThreadCounts[threadIdx].pmc[4] = pmc4 * normalizationFactor;
+                NormalizedThreadCounts[threadIdx].pmc[5] = pmc5 * normalizationFactor;
                 NormalizedThreadCounts[threadIdx].NormalizationFactor = normalizationFactor;
                 NormalizedTotalCounts.activeCycles += NormalizedThreadCounts[threadIdx].activeCycles;
                 NormalizedTotalCounts.instr += NormalizedThreadCounts[threadIdx].instr;
                 NormalizedTotalCounts.refTsc += NormalizedThreadCounts[threadIdx].refTsc;
-                NormalizedTotalCounts.pmc0 += NormalizedThreadCounts[threadIdx].pmc0;
-                NormalizedTotalCounts.pmc1 += NormalizedThreadCounts[threadIdx].pmc1;
-                NormalizedTotalCounts.pmc2 += NormalizedThreadCounts[threadIdx].pmc2;
-                NormalizedTotalCounts.pmc3 += NormalizedThreadCounts[threadIdx].pmc3;
-                NormalizedTotalCounts.pmc4 += NormalizedThreadCounts[threadIdx].pmc4;
-                NormalizedTotalCounts.pmc5 += NormalizedThreadCounts[threadIdx].pmc5;
+                NormalizedTotalCounts.pmc[0] += NormalizedThreadCounts[threadIdx].pmc[0];
+                NormalizedTotalCounts.pmc[1] += NormalizedThreadCounts[threadIdx].pmc[1];
+                NormalizedTotalCounts.pmc[2] += NormalizedThreadCounts[threadIdx].pmc[2];
+                NormalizedTotalCounts.pmc[3] += NormalizedThreadCounts[threadIdx].pmc[3];
+                NormalizedTotalCounts.pmc[4] += NormalizedThreadCounts[threadIdx].pmc[4];
+                NormalizedTotalCounts.pmc[5] += NormalizedThreadCounts[threadIdx].pmc[5];
             }
         }
 
@@ -255,8 +255,8 @@ namespace PmcReader.Intel
 
                 cpu.ReadPackagePowerCounter();
                 results.overallMetrics = computeMetrics("Overall", cpu.NormalizedTotalCounts);
-                results.overallCounterValues = cpu.GetOverallCounterValues(
-                    "int 128-bit vec", "int 256-bit vec", "128-bit fp32", "128-bit fp64", "256-bit FP32", "256-bit FP64", "Scalar FP32", "Scalar FP64");
+                results.overallCounterValues = cpu.GetOverallCounterValues( new String[] {
+                    "int 128-bit vec", "int 256-bit vec", "128-bit fp32", "128-bit fp64", "256-bit FP32", "256-bit FP64", "Scalar FP32", "Scalar FP64" });
                 return results;
             }
 
@@ -276,16 +276,16 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        FormatPercentage(counterData.pmc0, counterData.pmc0 + counterData.pmc1),
-                        string.Format("{0:F2}", 1000 * counterData.pmc1 / counterData.instr),
-                        FormatPercentage(counterData.pmc0, counterData.instr),
-                        FormatPercentage(counterData.pmc1, counterData.instr),
-                        FormatPercentage(counterData.pmc2, counterData.instr),
-                        FormatPercentage(counterData.pmc3, counterData.instr),
-                        FormatPercentage(counterData.pmc4, counterData.instr),
-                        FormatPercentage(counterData.pmc5, counterData.instr),
-                        FormatPercentage(counterData.pmc6, counterData.instr),
-                        FormatPercentage(counterData.pmc7, counterData.instr),
+                        FormatPercentage(counterData.pmc[0], counterData.pmc[0] + counterData.pmc[1]),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[1] / counterData.instr),
+                        FormatPercentage(counterData.pmc[0], counterData.instr),
+                        FormatPercentage(counterData.pmc[1], counterData.instr),
+                        FormatPercentage(counterData.pmc[2], counterData.instr),
+                        FormatPercentage(counterData.pmc[3], counterData.instr),
+                        FormatPercentage(counterData.pmc[4], counterData.instr),
+                        FormatPercentage(counterData.pmc[5], counterData.instr),
+                        FormatPercentage(counterData.pmc[6], counterData.instr),
+                        FormatPercentage(counterData.pmc[7], counterData.instr),
                 };
             }
         }
@@ -333,7 +333,7 @@ namespace PmcReader.Intel
 
                 cpu.ReadPackagePowerCounter();
                 results.overallMetrics = computeMetrics("Overall", cpu.NormalizedTotalCounts);
-                results.overallCounterValues = cpu.GetOverallCounterValues("License 1", "License 2", "License 3", "C0.1 State", "C0.2 State", "1T Active", "Paused", "Unused");
+                results.overallCounterValues = cpu.GetOverallCounterValues(new String[] { "License 1", "License 2", "License 3", "C0.1 State", "C0.2 State", "1T Active", "Paused", "Unused" });
                 return results;
             }
 
@@ -353,15 +353,15 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        FormatPercentage(counterData.pmc0, counterData.pmc0 + counterData.pmc1),
-                        string.Format("{0:F2}", 1000 * counterData.pmc1 / counterData.instr),
-                        FormatPercentage(counterData.pmc0, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc1, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc2, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc3, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc4, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc5, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc6, counterData.activeCycles)
+                        FormatPercentage(counterData.pmc[0], counterData.pmc[0] + counterData.pmc[1]),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[1] / counterData.instr),
+                        FormatPercentage(counterData.pmc[0], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[1], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[2], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[3], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[4], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[5], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[6], counterData.activeCycles)
                 };
             }
         }
@@ -409,7 +409,7 @@ namespace PmcReader.Intel
 
                 cpu.ReadPackagePowerCounter();
                 results.overallMetrics = computeMetrics("Overall", cpu.NormalizedTotalCounts);
-                results.overallCounterValues = cpu.GetOverallCounterValues("Load Buffer Full", "Mem RS Full", "Store Buffer Full", "LD Block 4K Alias", "LD Block Data Unknown", "Unused");
+                results.overallCounterValues = cpu.GetOverallCounterValues(new String[] { "Load Buffer Full", "Mem RS Full", "Store Buffer Full", "LD Block 4K Alias", "LD Block Data Unknown", "Unused" });
                 return results;
             }
 
@@ -429,13 +429,13 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        FormatPercentage(counterData.pmc0, counterData.pmc0 + counterData.pmc1),
-                        string.Format("{0:F2}", 1000 * counterData.pmc1 / counterData.instr),
-                        FormatPercentage(counterData.pmc0, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc1, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc2, counterData.activeCycles),
-                        string.Format("{0:F2}", 1000 * counterData.pmc3 / counterData.instr),
-                        string.Format("{0:F2}", 1000 * counterData.pmc4 / counterData.instr),
+                        FormatPercentage(counterData.pmc[0], counterData.pmc[0] + counterData.pmc[1]),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[1] / counterData.instr),
+                        FormatPercentage(counterData.pmc[0], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[1], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[2], counterData.activeCycles),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[3] / counterData.instr),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[4] / counterData.instr),
                 };
             }
         }
@@ -475,15 +475,15 @@ namespace PmcReader.Intel
                 int eCoreIdx = 0;
                 foreach (byte threadIdx in cpu.eCores)
                 {
-                    
+
                     results.unitMetrics[eCoreIdx] = computeMetrics("E: Thread " + threadIdx, cpu.NormalizedThreadCounts[threadIdx]);
                     eCoreIdx++;
                 }
 
                 cpu.ReadPackagePowerCounter();
                 results.overallMetrics = computeMetrics("Overall", cpu.NormalizedTotalCounts);
-                results.overallCounterValues = cpu.GetOverallCounterValues(
-                    "Allocation Restriction", "Mem Scheduler Full", "Non-mem Scheduler Full", "Registers Full", "ROB Full", "Serialization");
+                results.overallCounterValues = cpu.GetOverallCounterValues( new String[] {
+                    "Allocation Restriction", "Mem Scheduler Full", "Non-mem Scheduler Full", "Registers Full", "ROB Full", "Serialization" });
                 return results;
             }
 
@@ -503,14 +503,14 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        FormatPercentage(counterData.pmc0, counterData.pmc0 + counterData.pmc1),
-                        string.Format("{0:F2}", 1000 * counterData.pmc1 / counterData.instr),
-                        FormatPercentage(counterData.pmc0, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc1, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc2, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc3, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc4, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc5, counterData.activeCycles)
+                        FormatPercentage(counterData.pmc[0], counterData.pmc[0] + counterData.pmc[1]),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[1] / counterData.instr),
+                        FormatPercentage(counterData.pmc[0], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[1], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[2], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[3], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[4], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[5], counterData.activeCycles)
                 };
             }
         }
@@ -579,21 +579,21 @@ namespace PmcReader.Intel
             private string[] computeMetrics(string label, NormalizedCoreCounterData counterData)
             {
                 // L1 and load fill buffer hits = loads that were not served from L2, L3, or DRAM
-                float l1FbHits = counterData.pmc0 - counterData.pmc1 - counterData.pmc2 - counterData.pmc3;
-                float l2Reqs = counterData.pmc0 - l1FbHits; // L2 requests = l1 and fill buffer misses
-                float l3Reqs = l2Reqs - counterData.pmc1;
+                float l1FbHits = counterData.pmc[0] - counterData.pmc[1] - counterData.pmc[2] - counterData.pmc[3];
+                float l2Reqs = counterData.pmc[0] - l1FbHits; // L2 requests = l1 and fill buffer misses
+                float l3Reqs = l2Reqs - counterData.pmc[1];
                 return new string[] { label,
                         FormatLargeNumber(counterData.activeCycles),
                         FormatLargeNumber(counterData.instr),
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        FormatPercentage(l1FbHits, counterData.pmc0),                            // L1 and fill buffer hitrate
+                        FormatPercentage(l1FbHits, counterData.pmc[0]),                            // L1 and fill buffer hitrate
                         string.Format("{0:F2}", 1000 * l2Reqs / counterData.instr),              // L1 MPKI
-                        FormatPercentage(counterData.pmc1, l2Reqs),                              // L2 hitrate
+                        FormatPercentage(counterData.pmc[1], l2Reqs),                              // L2 hitrate
                         string.Format("{0:F2}", 1000 * l3Reqs / counterData.instr),              // L2 MPKI
-                        FormatPercentage(counterData.pmc2, l3Reqs),                              // L3 hitrate
-                        string.Format("{0:F2}", 1000 * counterData.pmc3 / counterData.instr)     // L3 MPKI
+                        FormatPercentage(counterData.pmc[2], l3Reqs),                              // L3 hitrate
+                        string.Format("{0:F2}", 1000 * counterData.pmc[3] / counterData.instr)     // L3 MPKI
                 };
             }
         }

--- a/Intel/GoldmontPlus.cs
+++ b/Intel/GoldmontPlus.cs
@@ -101,11 +101,11 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        FormatPercentage(counterData.pmc1, counterData.pmc0),
-                        string.Format("{0:F2}", 1000 * counterData.pmc1 / counterData.instr),
-                        string.Format("{0:F2}", 1000 * counterData.pmc2 / counterData.instr),
-                        string.Format("{0:F2}", 1000 * counterData.pmc3 / counterData.instr),
-                        string.Format("{0:F2}", counterData.pmc1 / counterData.pmc0)
+                        FormatPercentage(counterData.pmc[1], counterData.pmc[0]),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[1] / counterData.instr),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[2] / counterData.instr),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[3] / counterData.instr),
+                        string.Format("{0:F2}", counterData.pmc[1] / counterData.pmc[0])
                 };
             }
         }
@@ -173,11 +173,11 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        FormatPercentage(counterData.pmc1, counterData.pmc0),
-                        string.Format("{0:F2}", 1000 * ((counterData.pmc0 - counterData.pmc1) / counterData.instr)),
-                        FormatLargeNumber(counterData.pmc1 * 64) + "B/s",
-                        FormatPercentage(counterData.pmc2, counterData.activeCycles),
-                        string.Format("{0:F2}", 1000 * counterData.pmc3 / counterData.instr),
+                        FormatPercentage(counterData.pmc[1], counterData.pmc[0]),
+                        string.Format("{0:F2}", 1000 * ((counterData.pmc[0] - counterData.pmc[1]) / counterData.instr)),
+                        FormatLargeNumber(counterData.pmc[1] * 64) + "B/s",
+                        FormatPercentage(counterData.pmc[2], counterData.activeCycles),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[3] / counterData.instr),
                 };
             }
         }
@@ -240,7 +240,7 @@ namespace PmcReader.Intel
 
             private string[] computeMetrics(string label, NormalizedCoreCounterData counterData)
             {
-                float completedWalks = counterData.pmc0 + counterData.pmc1 + counterData.pmc2;
+                float completedWalks = counterData.pmc[0] + counterData.pmc[1] + counterData.pmc[2];
                 return new string[] { label,
                         FormatLargeNumber(counterData.activeCycles),
                         FormatLargeNumber(counterData.instr),
@@ -248,11 +248,11 @@ namespace PmcReader.Intel
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
                         string.Format("{0:F2}", 1000 * completedWalks / counterData.instr),
-                        string.Format("{0:F2} clks", counterData.pmc3 / completedWalks),
-                        FormatPercentage(counterData.pmc3, counterData.activeCycles),
-                        string.Format("{0:F2}", 1000 * counterData.pmc0 / counterData.instr),
-                        string.Format("{0:F2}", 1000 * counterData.pmc1 / counterData.instr),
-                        string.Format("{0:F2}", 1000 * counterData.pmc2 / counterData.instr)
+                        string.Format("{0:F2} clks", counterData.pmc[3] / completedWalks),
+                        FormatPercentage(counterData.pmc[3], counterData.activeCycles),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[0] / counterData.instr),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[1] / counterData.instr),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[2] / counterData.instr)
                 };
             }
         }
@@ -315,7 +315,7 @@ namespace PmcReader.Intel
 
             private string[] computeMetrics(string label, NormalizedCoreCounterData counterData)
             {
-                float completedWalks = counterData.pmc0 + counterData.pmc2;
+                float completedWalks = counterData.pmc[0] + counterData.pmc[2];
                 return new string[] { label,
                         FormatLargeNumber(counterData.activeCycles),
                         FormatLargeNumber(counterData.instr),
@@ -323,11 +323,11 @@ namespace PmcReader.Intel
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
                         string.Format("{0:F2}", 1000 * completedWalks / counterData.instr),
-                        string.Format("{0:F2} clks", counterData.pmc3 / completedWalks),
-                        FormatPercentage(counterData.pmc3, counterData.activeCycles),
-                        string.Format("{0:F2}", 1000 * counterData.pmc0 / counterData.instr),
-                        string.Format("{0:F2}", 1000 * counterData.pmc2 / counterData.instr),
-                        string.Format("{0:F2}", 1000 * counterData.pmc1 / counterData.instr)
+                        string.Format("{0:F2} clks", counterData.pmc[3] / completedWalks),
+                        FormatPercentage(counterData.pmc[3], counterData.activeCycles),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[0] / counterData.instr),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[2] / counterData.instr),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[1] / counterData.instr)
                 };
             }
         }
@@ -397,11 +397,11 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        FormatPercentage(counterData.pmc1, counterData.activeCycles),
-                        string.Format("{0:F2}", 1000 * counterData.pmc1 / counterData.instr),
-                        string.Format("{0:F2}", 1000 * counterData.pmc0 / counterData.instr),
-                        string.Format("{0:F2}", 1000 * counterData.pmc2 / counterData.instr),
-                        string.Format("{0:F2}", 1000 * counterData.pmc3 / counterData.instr),
+                        FormatPercentage(counterData.pmc[1], counterData.activeCycles),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[1] / counterData.instr),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[0] / counterData.instr),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[2] / counterData.instr),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[3] / counterData.instr),
                 };
             }
         }
@@ -471,10 +471,10 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        string.Format("{0:F2}", 1000 * counterData.pmc0 / counterData.instr),
-                        string.Format("{0:F2}", 1000 * counterData.pmc1 / counterData.instr),
-                        string.Format("{0:F2}", 1000 * counterData.pmc2 / counterData.instr),
-                        string.Format("{0:F2}", 1000 * counterData.pmc3 / counterData.instr),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[0] / counterData.instr),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[1] / counterData.instr),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[2] / counterData.instr),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[3] / counterData.instr),
                 };
             }
         }
@@ -544,11 +544,11 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        string.Format("{0:F2}", 1000 * counterData.pmc0 / counterData.instr),
-                        string.Format("{0:F2}", 1000 * counterData.pmc1 / counterData.instr),
-                        string.Format("{0:F2}", 1000 * counterData.pmc2 / counterData.instr),
-                        string.Format("{0:F2}", 1000 * counterData.pmc3 / counterData.instr),
-                        FormatLargeNumber(counterData.pmc3)
+                        string.Format("{0:F2}", 1000 * counterData.pmc[0] / counterData.instr),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[1] / counterData.instr),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[2] / counterData.instr),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[3] / counterData.instr),
+                        FormatLargeNumber(counterData.pmc[3])
                 };
             }
         }
@@ -618,13 +618,13 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        FormatLargeNumber(counterData.pmc0),
-                        FormatPercentage((counterData.pmc0 - counterData.pmc1), counterData.pmc0),
-                        string.Format("{0:F2}", 1000 * counterData.pmc1 / counterData.instr),
-                        FormatPercentage((counterData.pmc1 - counterData.pmc2), counterData.pmc1),
-                        string.Format("{0:F2}", 1000 * counterData.pmc2 / counterData.instr),
-                        FormatPercentage((counterData.pmc0 - counterData.pmc3), counterData.pmc0),
-                        string.Format("{0:F2}", 1000 * counterData.pmc3 / counterData.instr),
+                        FormatLargeNumber(counterData.pmc[0]),
+                        FormatPercentage((counterData.pmc[0] - counterData.pmc[1]), counterData.pmc[0]),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[1] / counterData.instr),
+                        FormatPercentage((counterData.pmc[1] - counterData.pmc[2]), counterData.pmc[1]),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[2] / counterData.instr),
+                        FormatPercentage((counterData.pmc[0] - counterData.pmc[3]), counterData.pmc[0]),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[3] / counterData.instr),
                 };
             }
         }
@@ -697,11 +697,11 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower), // instr/watt
-                        FormatPercentage(counterData.pmc0, counterData.pmc1),
-                        FormatLargeNumber(64 * counterData.pmc0) + "B/s",
-                        string.Format("{0:F2}", 1000 * (counterData.pmc1 - counterData.pmc0) / counterData.instr),
-                        FormatPercentage(counterData.pmc2, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc3, counterData.activeCycles)
+                        FormatPercentage(counterData.pmc[0], counterData.pmc[1]),
+                        FormatLargeNumber(64 * counterData.pmc[0]) + "B/s",
+                        string.Format("{0:F2}", 1000 * (counterData.pmc[1] - counterData.pmc[0]) / counterData.instr),
+                        FormatPercentage(counterData.pmc[2], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[3], counterData.activeCycles)
                 };
             }
         }
@@ -771,10 +771,10 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        FormatPercentage(counterData.pmc0, totalSlots),
-                        FormatPercentage(counterData.pmc1, totalSlots),
-                        FormatPercentage(counterData.pmc2, totalSlots),
-                        FormatPercentage(counterData.pmc3, totalSlots)
+                        FormatPercentage(counterData.pmc[0], totalSlots),
+                        FormatPercentage(counterData.pmc[1], totalSlots),
+                        FormatPercentage(counterData.pmc[2], totalSlots),
+                        FormatPercentage(counterData.pmc[3], totalSlots)
                 };
             }
         }
@@ -830,10 +830,10 @@ namespace PmcReader.Intel
 
             private string[] computeMetrics(string label, NormalizedCoreCounterData counterData)
             {
-                float oneOp = counterData.pmc0 - counterData.pmc1;
-                float twoOps = counterData.pmc1 - counterData.pmc2;
-                float threeOps = counterData.pmc2 - counterData.pmc3;
-                float fourOps = counterData.pmc3;
+                float oneOp = counterData.pmc[0] - counterData.pmc[1];
+                float twoOps = counterData.pmc[1] - counterData.pmc[2];
+                float threeOps = counterData.pmc[2] - counterData.pmc[3];
+                float fourOps = counterData.pmc[3];
                 float totalOps = oneOp + 2 * twoOps + 3 * threeOps + 4 * fourOps;
                 return new string[] { label,
                         FormatLargeNumber(counterData.activeCycles),
@@ -842,7 +842,7 @@ namespace PmcReader.Intel
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
                         string.Format("{0:F2}", totalOps / counterData.activeCycles),
-                        FormatPercentage(counterData.pmc0, counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[0], counterData.activeCycles),
                         FormatPercentage(oneOp, counterData.activeCycles),
                         FormatPercentage(twoOps, counterData.activeCycles),
                         FormatPercentage(threeOps, counterData.activeCycles),
@@ -919,11 +919,11 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower), // instr/watt
-                        FormatPercentage(counterData.pmc0, counterData.pmc1),
-                        FormatLargeNumber(64 * counterData.pmc0) + "B/s",
-                        string.Format("{0:F2}", 1000 * counterData.pmc0 / counterData.instr),
-                        FormatPercentage(counterData.pmc2, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc3, counterData.activeCycles)
+                        FormatPercentage(counterData.pmc[0], counterData.pmc[1]),
+                        FormatLargeNumber(64 * counterData.pmc[0]) + "B/s",
+                        string.Format("{0:F2}", 1000 * counterData.pmc[0] / counterData.instr),
+                        FormatPercentage(counterData.pmc[2], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[3], counterData.activeCycles)
                 };
             }
         }

--- a/Intel/Haswell.cs
+++ b/Intel/Haswell.cs
@@ -110,10 +110,10 @@ namespace PmcReader.Intel
                     overall ? string.Format("{0:F2} W", counterData.pp0Power) : "N/A",
                     overall ? FormatLargeNumber(counterData.instr / counterData.packagePower) : "N/A",
                     overall ? FormatLargeNumber(counterData.instr / counterData.pp0Power) : "N/A",
-                    string.Format("{0:F2}%", 100 * counterData.pmc0 / counterData.activeCycles),
-                    string.Format("{0:F2}%", 100 * counterData.pmc1 / counterData.activeCycles),
-                    string.Format("{0:F2}%", 100 * counterData.pmc2 / counterData.activeCycles),
-                    string.Format("{0:F2}%", 100 * counterData.pmc3 / counterData.activeCycles) };
+                    string.Format("{0:F2}%", 100 * counterData.pmc[0] / counterData.activeCycles),
+                    string.Format("{0:F2}%", 100 * counterData.pmc[1] / counterData.activeCycles),
+                    string.Format("{0:F2}%", 100 * counterData.pmc[2] / counterData.activeCycles),
+                    string.Format("{0:F2}%", 100 * counterData.pmc[3] / counterData.activeCycles) };
             }
         }
 
@@ -188,10 +188,10 @@ namespace PmcReader.Intel
                     FormatLargeNumber(counterData.activeCycles),
                     FormatLargeNumber(counterData.instr),
                     string.Format("{0:F2}", ipc),
-                    string.Format("{0:F2}%", 100 * counterData.pmc0 / counterData.activeCycles),
-                    string.Format("{0:F2}%", 100 * counterData.pmc1 / counterData.activeCycles),
-                    string.Format("{0:F2}%", 100 * counterData.pmc2 / counterData.activeCycles),
-                    string.Format("{0:F2}%", 100 * counterData.pmc3 / counterData.activeCycles) };
+                    string.Format("{0:F2}%", 100 * counterData.pmc[0] / counterData.activeCycles),
+                    string.Format("{0:F2}%", 100 * counterData.pmc[1] / counterData.activeCycles),
+                    string.Format("{0:F2}%", 100 * counterData.pmc[2] / counterData.activeCycles),
+                    string.Format("{0:F2}%", 100 * counterData.pmc[3] / counterData.activeCycles) };
             }
         }
 
@@ -260,14 +260,14 @@ namespace PmcReader.Intel
                     FormatLargeNumber(counterData.activeCycles),
                     FormatLargeNumber(counterData.instr),
                     string.Format("{0:F2}", ipc),
-                    FormatLargeNumber(counterData.pmc1),
-                    FormatLargeNumber(counterData.pmc2),
-                    FormatLargeNumber(counterData.pmc3),
-                    string.Format("{0:F2}", (counterData.pmc1 + counterData.pmc2) / counterData.instr),
-                    string.Format("{0:F2}%", 100 * counterData.pmc1 / (counterData.pmc1 + counterData.pmc2)),
-                    string.Format("{0:F2} clks", counterData.pmc0 / counterData.pmc2),
-                    string.Format("{0:F2}%", 100 * counterData.pmc0 / counterData.activeCycles),
-                    string.Format("{0:F2}%", 100 * counterData.pmc3 / counterData.pmc2) };
+                    FormatLargeNumber(counterData.pmc[1]),
+                    FormatLargeNumber(counterData.pmc[2]),
+                    FormatLargeNumber(counterData.pmc[3]),
+                    string.Format("{0:F2}", (counterData.pmc[1] + counterData.pmc[2]) / counterData.instr),
+                    string.Format("{0:F2}%", 100 * counterData.pmc[1] / (counterData.pmc[1] + counterData.pmc[2])),
+                    string.Format("{0:F2} clks", counterData.pmc[0] / counterData.pmc[2]),
+                    string.Format("{0:F2}%", 100 * counterData.pmc[0] / counterData.activeCycles),
+                    string.Format("{0:F2}%", 100 * counterData.pmc[3] / counterData.pmc[2]) };
             }
         }
 
@@ -336,13 +336,13 @@ namespace PmcReader.Intel
                     FormatLargeNumber(counterData.activeCycles),
                     FormatLargeNumber(counterData.instr),
                     string.Format("{0:F2}", ipc),
-                    string.Format("{0:F2}%", 100 * (counterData.pmc0 + counterData.pmc1) / (counterData.pmc0 + counterData.pmc1 + counterData.pmc2 + counterData.pmc3)),
-                    string.Format("{0:F2}%", 100 * counterData.pmc0 / (counterData.pmc0 + counterData.pmc2)),
-                    string.Format("{0:F2}%", 100 * counterData.pmc1 / (counterData.pmc1 + counterData.pmc3)),
-                    FormatLargeNumber(counterData.pmc0),
-                    FormatLargeNumber(counterData.pmc0 + counterData.pmc2),
-                    FormatLargeNumber(counterData.pmc1),
-                    FormatLargeNumber(counterData.pmc1 + counterData.pmc3)
+                    string.Format("{0:F2}%", 100 * (counterData.pmc[0] + counterData.pmc[1]) / (counterData.pmc[0] + counterData.pmc[1] + counterData.pmc[2] + counterData.pmc[3])),
+                    string.Format("{0:F2}%", 100 * counterData.pmc[0] / (counterData.pmc[0] + counterData.pmc[2])),
+                    string.Format("{0:F2}%", 100 * counterData.pmc[1] / (counterData.pmc[1] + counterData.pmc[3])),
+                    FormatLargeNumber(counterData.pmc[0]),
+                    FormatLargeNumber(counterData.pmc[0] + counterData.pmc[2]),
+                    FormatLargeNumber(counterData.pmc[1]),
+                    FormatLargeNumber(counterData.pmc[1] + counterData.pmc[3])
                 };
             }
         }
@@ -415,10 +415,10 @@ namespace PmcReader.Intel
                         FormatLargeNumber(counterData.activeCycles),
                         FormatLargeNumber(counterData.instr),
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
-                        string.Format("{0:F2}%", counterData.pmc0 / counterData.activeCycles * 100),
-                        string.Format("{0:F2}%", counterData.pmc1 / counterData.activeCycles * 100),
-                        string.Format("{0:F2}%", counterData.pmc2 / counterData.activeCycles * 100),
-                        string.Format("{0:F2}%", counterData.pmc3 / counterData.activeCycles * 100)};
+                        string.Format("{0:F2}%", counterData.pmc[0] / counterData.activeCycles * 100),
+                        string.Format("{0:F2}%", counterData.pmc[1] / counterData.activeCycles * 100),
+                        string.Format("{0:F2}%", counterData.pmc[2] / counterData.activeCycles * 100),
+                        string.Format("{0:F2}%", counterData.pmc[3] / counterData.activeCycles * 100)};
             }
         }
 
@@ -490,10 +490,10 @@ namespace PmcReader.Intel
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * (counterData.pmc0 - counterData.pmc1) / counterData.pmc0),
-                        FormatLargeNumber((counterData.pmc0 - counterData.pmc1) * 64) + "B",
-                        FormatLargeNumber(counterData.pmc2 * 64) + "B",
-                        FormatLargeNumber(counterData.pmc3 * 64) + "B",
+                        string.Format("{0:F2}%", 100 * (counterData.pmc[0] - counterData.pmc[1]) / counterData.pmc[0]),
+                        FormatLargeNumber((counterData.pmc[0] - counterData.pmc[1]) * 64) + "B",
+                        FormatLargeNumber(counterData.pmc[2] * 64) + "B",
+                        FormatLargeNumber(counterData.pmc[3] * 64) + "B",
                 };
             }
         }
@@ -558,21 +558,21 @@ namespace PmcReader.Intel
 
             private string[] computeMetrics(string label, NormalizedCoreCounterData counterData)
             {
-                float l1LfbHit = counterData.pmc0 - counterData.pmc1;
-                float l2Hit = counterData.pmc1 - counterData.pmc2;
-                float l3hit = counterData.pmc2 - counterData.pmc3;
+                float l1LfbHit = counterData.pmc[0] - counterData.pmc[1];
+                float l2Hit = counterData.pmc[1] - counterData.pmc[2];
+                float l3hit = counterData.pmc[2] - counterData.pmc[3];
                 return new string[] { label,
                         FormatLargeNumber(counterData.activeCycles),
                         FormatLargeNumber(counterData.instr),
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
-                        FormatLargeNumber(counterData.pmc0),
-                        string.Format("{0:F2}%", 100 * l1LfbHit / counterData.pmc0),
-                        string.Format("{0:F2}", 1000 * counterData.pmc1 / counterData.instr),
-                        string.Format("{0:F2}%", 100 * l2Hit / counterData.pmc0),
-                        string.Format("{0:F2}", 1000 * counterData.pmc2 / counterData.instr),
-                        string.Format("{0:F2}%", 100 * l3hit / counterData.pmc0),
-                        string.Format("{0:F2}", 1000 * counterData.pmc3 / counterData.instr),
-                        string.Format("{0:F2}%", 100 * counterData.pmc3 / counterData.pmc0),
+                        FormatLargeNumber(counterData.pmc[0]),
+                        string.Format("{0:F2}%", 100 * l1LfbHit / counterData.pmc[0]),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[1] / counterData.instr),
+                        string.Format("{0:F2}%", 100 * l2Hit / counterData.pmc[0]),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[2] / counterData.instr),
+                        string.Format("{0:F2}%", 100 * l3hit / counterData.pmc[0]),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[3] / counterData.instr),
+                        string.Format("{0:F2}%", 100 * counterData.pmc[3] / counterData.pmc[0]),
                 };
             }
         }
@@ -633,10 +633,10 @@ namespace PmcReader.Intel
 
             private string[] computeMetrics(string label, NormalizedCoreCounterData counterData)
             {
-                float oneOp = counterData.pmc0 - counterData.pmc1;
-                float twoOps = counterData.pmc1 - counterData.pmc2;
-                float threeOps = counterData.pmc2 - counterData.pmc3;
-                float opsIssued = oneOp + 2 * twoOps + 3 * threeOps + 4 * counterData.pmc3;
+                float oneOp = counterData.pmc[0] - counterData.pmc[1];
+                float twoOps = counterData.pmc[1] - counterData.pmc[2];
+                float threeOps = counterData.pmc[2] - counterData.pmc[3];
+                float opsIssued = oneOp + 2 * twoOps + 3 * threeOps + 4 * counterData.pmc[3];
                 return new string[] { label,
                         FormatLargeNumber(counterData.activeCycles),
                         FormatLargeNumber(counterData.instr),
@@ -646,8 +646,8 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}%", 100 * oneOp / counterData.activeCycles),
                         string.Format("{0:F2}%", 100 * twoOps / counterData.activeCycles),
                         string.Format("{0:F2}%", 100 * threeOps / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * counterData.pmc3 / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * counterData.pmc0 / counterData.activeCycles),
+                        string.Format("{0:F2}%", 100 * counterData.pmc[3] / counterData.activeCycles),
+                        string.Format("{0:F2}%", 100 * counterData.pmc[0] / counterData.activeCycles),
                 };
             }
         }
@@ -713,11 +713,11 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        FormatPercentage(counterData.pmc0, counterData.pmc0 + counterData.pmc1),
-                        string.Format("{0:F2}", 1000 * counterData.pmc1 / counterData.instr),
-                        FormatLargeNumber(counterData.pmc0),
-                        FormatPercentage(counterData.pmc2, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc3, counterData.activeCycles)
+                        FormatPercentage(counterData.pmc[0], counterData.pmc[0] + counterData.pmc[1]),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[1] / counterData.instr),
+                        FormatLargeNumber(counterData.pmc[0]),
+                        FormatPercentage(counterData.pmc[2], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[3], counterData.activeCycles)
                 };
             }
         }
@@ -783,10 +783,10 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        FormatPercentage(counterData.pmc0, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc1, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc2, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc3, counterData.activeCycles)
+                        FormatPercentage(counterData.pmc[0], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[1], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[2], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[3], counterData.activeCycles)
                 };
             }
         }
@@ -841,10 +841,10 @@ namespace PmcReader.Intel
 
             private string[] computeMetrics(string label, NormalizedCoreCounterData counterData)
             {
-                float retireSlotsUsed = (counterData.pmc0 - counterData.pmc1) + 
-                    2 * (counterData.pmc1 - counterData.pmc2) + 
-                    3 * (counterData.pmc2 - counterData.pmc3) + 
-                    4 * counterData.pmc3;
+                float retireSlotsUsed = (counterData.pmc[0] - counterData.pmc[1]) + 
+                    2 * (counterData.pmc[1] - counterData.pmc[2]) + 
+                    3 * (counterData.pmc[2] - counterData.pmc[3]) + 
+                    4 * counterData.pmc[3];
 
                 return new string[] { label,
                         FormatLargeNumber(counterData.activeCycles),
@@ -855,11 +855,11 @@ namespace PmcReader.Intel
                         FormatLargeNumber(retireSlotsUsed),
                         string.Format("{0:F2}", retireSlotsUsed / counterData.instr),
                         string.Format("{0:F2}", retireSlotsUsed / counterData.activeCycles),
-                        FormatPercentage(counterData.pmc0, counterData.activeCycles), // retire active - at least 1 slot used
-                        FormatPercentage(counterData.pmc0 - counterData.pmc1, counterData.activeCycles), // 1 slot
-                        FormatPercentage(counterData.pmc1 - counterData.pmc2, counterData.activeCycles), // 2 slots
-                        FormatPercentage(counterData.pmc2 - counterData.pmc3, counterData.activeCycles), // 3 slots
-                        FormatPercentage(counterData.pmc3, counterData.activeCycles) // 4 slots
+                        FormatPercentage(counterData.pmc[0], counterData.activeCycles), // retire active - at least 1 slot used
+                        FormatPercentage(counterData.pmc[0] - counterData.pmc[1], counterData.activeCycles), // 1 slot
+                        FormatPercentage(counterData.pmc[1] - counterData.pmc[2], counterData.activeCycles), // 2 slots
+                        FormatPercentage(counterData.pmc[2] - counterData.pmc[3], counterData.activeCycles), // 3 slots
+                        FormatPercentage(counterData.pmc[3], counterData.activeCycles) // 4 slots
                 };
             }
         }
@@ -926,20 +926,20 @@ namespace PmcReader.Intel
 
             private string[] computeMetrics(string label, NormalizedCoreCounterData counterData, bool overall)
             {
-                float oneOp = counterData.pmc0 - counterData.pmc1;
-                float twoOps = counterData.pmc1 - counterData.pmc2;
-                float threeOps = counterData.pmc2 - counterData.pmc3;
-                float opCacheOps = oneOp + 2 * twoOps + 3 * threeOps + 4 * counterData.pmc3;
+                float oneOp = counterData.pmc[0] - counterData.pmc[1];
+                float twoOps = counterData.pmc[1] - counterData.pmc[2];
+                float threeOps = counterData.pmc[2] - counterData.pmc[3];
+                float opCacheOps = oneOp + 2 * twoOps + 3 * threeOps + 4 * counterData.pmc[3];
                 return new string[] { label,
                        FormatLargeNumber(counterData.activeCycles),
                        FormatLargeNumber(counterData.instr),
                        string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                        overall ? string.Format("{0:F2} W", counterData.packagePower) : "N/A",
                        overall ? FormatLargeNumber(counterData.instr / counterData.packagePower) : "N/A",
-                       FormatLargeNumber(64 * counterData.pmc1) + "B/s",
-                       string.Format("{0:F2} clk", counterData.pmc0 / counterData.pmc1),
-                       FormatPercentage(counterData.pmc2, counterData.activeCycles),
-                       FormatPercentage(counterData.pmc3, counterData.activeCycles),
+                       FormatLargeNumber(64 * counterData.pmc[1]) + "B/s",
+                       string.Format("{0:F2} clk", counterData.pmc[0] / counterData.pmc[1]),
+                       FormatPercentage(counterData.pmc[2], counterData.activeCycles),
+                       FormatPercentage(counterData.pmc[3], counterData.activeCycles),
                 };
             }
         }

--- a/Intel/SandyBridge.cs
+++ b/Intel/SandyBridge.cs
@@ -104,9 +104,9 @@ namespace PmcReader.Intel
                         FormatLargeNumber(counterData.activeCycles),
                         FormatLargeNumber(counterData.instr),
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
-                        string.Format("{0:F2}%", counterData.pmc0 / counterData.activeCycles * 100),
-                        string.Format("{0:F2}%", counterData.pmc1 / counterData.activeCycles * 100),
-                        string.Format("{0:F2}%", counterData.pmc2 / counterData.activeCycles * 100)};
+                        string.Format("{0:F2}%", counterData.pmc[0] / counterData.activeCycles * 100),
+                        string.Format("{0:F2}%", counterData.pmc[1] / counterData.activeCycles * 100),
+                        string.Format("{0:F2}%", counterData.pmc[2] / counterData.activeCycles * 100)};
             }
         }
 
@@ -182,9 +182,9 @@ namespace PmcReader.Intel
                         FormatLargeNumber(counterData.activeCycles),
                         FormatLargeNumber(counterData.instr),
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
-                        string.Format("{0:F2}%", counterData.pmc0 / counterData.activeCycles * 100),
-                        string.Format("{0:F2}%", counterData.pmc1 / counterData.activeCycles * 100),
-                        string.Format("{0:F2}%", counterData.pmc2 / counterData.activeCycles * 100)};
+                        string.Format("{0:F2}%", counterData.pmc[0] / counterData.activeCycles * 100),
+                        string.Format("{0:F2}%", counterData.pmc[1] / counterData.activeCycles * 100),
+                        string.Format("{0:F2}%", counterData.pmc[2] / counterData.activeCycles * 100)};
             }
         }
 
@@ -253,10 +253,10 @@ namespace PmcReader.Intel
                         FormatLargeNumber(counterData.activeCycles),
                         FormatLargeNumber(counterData.instr),
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
-                        string.Format("{0:F2}%", counterData.pmc0 / counterData.activeCycles * 100),
-                        string.Format("{0:F2}%", counterData.pmc1 / counterData.activeCycles * 100),
-                        string.Format("{0:F2}%", counterData.pmc2 / counterData.activeCycles * 100),
-                        string.Format("{0:F2}%", counterData.pmc3 / counterData.activeCycles * 100)};
+                        string.Format("{0:F2}%", counterData.pmc[0] / counterData.activeCycles * 100),
+                        string.Format("{0:F2}%", counterData.pmc[1] / counterData.activeCycles * 100),
+                        string.Format("{0:F2}%", counterData.pmc[2] / counterData.activeCycles * 100),
+                        string.Format("{0:F2}%", counterData.pmc[3] / counterData.activeCycles * 100)};
             }
         }
 
@@ -314,10 +314,10 @@ namespace PmcReader.Intel
                         FormatLargeNumber(counterData.activeCycles),
                         FormatLargeNumber(counterData.instr),
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
-                        string.Format("{0:F2}%", counterData.pmc0 / counterData.activeCycles * 100),
-                        string.Format("{0:F2}%", counterData.pmc1 / counterData.activeCycles * 100),
-                        string.Format("{0:F2}%", counterData.pmc2 / counterData.activeCycles * 100),
-                        string.Format("{0:F2}%", counterData.pmc3 / counterData.activeCycles * 100)};
+                        string.Format("{0:F2}%", counterData.pmc[0] / counterData.activeCycles * 100),
+                        string.Format("{0:F2}%", counterData.pmc[1] / counterData.activeCycles * 100),
+                        string.Format("{0:F2}%", counterData.pmc[2] / counterData.activeCycles * 100),
+                        string.Format("{0:F2}%", counterData.pmc[3] / counterData.activeCycles * 100)};
             }
         }
 
@@ -376,10 +376,10 @@ namespace PmcReader.Intel
                         FormatLargeNumber(counterData.activeCycles),
                         FormatLargeNumber(counterData.instr),
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
-                        string.Format("{0:F2}%", counterData.pmc0 / counterData.activeCycles * 100),
-                        string.Format("{0:F2}%", counterData.pmc1 / counterData.activeCycles * 100),
-                        string.Format("{0:F2}%", counterData.pmc2 / counterData.activeCycles * 100),
-                        string.Format("{0:F2}%", counterData.pmc3 / counterData.activeCycles * 100)};
+                        string.Format("{0:F2}%", counterData.pmc[0] / counterData.activeCycles * 100),
+                        string.Format("{0:F2}%", counterData.pmc[1] / counterData.activeCycles * 100),
+                        string.Format("{0:F2}%", counterData.pmc[2] / counterData.activeCycles * 100),
+                        string.Format("{0:F2}%", counterData.pmc[3] / counterData.activeCycles * 100)};
             }
         }
 
@@ -441,15 +441,15 @@ namespace PmcReader.Intel
             private string[] computeMetrics(string label, NormalizedCoreCounterData counterData, bool total)
             {
                 float avgCycles = total ? counterData.activeCycles / cpu.GetThreadCount() : counterData.activeCycles;
-                float reqLatency = counterData.pmc0 / counterData.pmc1;
+                float reqLatency = counterData.pmc[0] / counterData.pmc[1];
                 return new string[] { label,
                         FormatLargeNumber(counterData.activeCycles),
                         FormatLargeNumber(counterData.instr),
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
-                        FormatLargeNumber(counterData.pmc1),
-                        string.Format("{0:F2}%", counterData.pmc3 / counterData.activeCycles * 100),
-                        string.Format("{0:F2}", counterData.pmc0 / counterData.pmc3),
-                        string.Format("{0:F2}%", counterData.pmc2 / counterData.activeCycles * 100),
+                        FormatLargeNumber(counterData.pmc[1]),
+                        string.Format("{0:F2}%", counterData.pmc[3] / counterData.activeCycles * 100),
+                        string.Format("{0:F2}", counterData.pmc[0] / counterData.pmc[3]),
+                        string.Format("{0:F2}%", counterData.pmc[2] / counterData.activeCycles * 100),
                         string.Format("{0:F2} clk", reqLatency),
                         string.Format("{0:F2} ns", (1000000000 / avgCycles) * reqLatency)
                 };
@@ -514,9 +514,9 @@ namespace PmcReader.Intel
 
             private string[] computeMetrics(string label, NormalizedCoreCounterData counterData, bool total)
             {
-                float scalarFlops = counterData.pmc0;
-                float sseFlops = counterData.pmc1 * 4;
-                float avxFlops = counterData.pmc2 * 8;
+                float scalarFlops = counterData.pmc[0];
+                float sseFlops = counterData.pmc[1] * 4;
+                float avxFlops = counterData.pmc[2] * 8;
                 return new string[] { label,
                         total ? string.Format("{0:F2} W", counterData.packagePower) : "N/A",
                         total ? string.Format("{0:F2} W", counterData.pp0Power) : "N/A",
@@ -524,12 +524,12 @@ namespace PmcReader.Intel
                         FormatLargeNumber(counterData.instr),
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         total ? FormatLargeNumber(counterData.instr / counterData.packagePower) : "N/A",
-                        FormatLargeNumber(scalarFlops + sseFlops + avxFlops + counterData.pmc3),
-                        string.Format("{0:F2}", (scalarFlops + sseFlops + avxFlops + counterData.pmc3) / counterData.activeCycles),
+                        FormatLargeNumber(scalarFlops + sseFlops + avxFlops + counterData.pmc[3]),
+                        string.Format("{0:F2}", (scalarFlops + sseFlops + avxFlops + counterData.pmc[3]) / counterData.activeCycles),
                         FormatLargeNumber(scalarFlops),
                         FormatLargeNumber(sseFlops),
                         FormatLargeNumber(avxFlops),
-                        FormatLargeNumber(counterData.pmc3)};
+                        FormatLargeNumber(counterData.pmc[3])};
             }
         }
 
@@ -589,19 +589,19 @@ namespace PmcReader.Intel
 
             private string[] computeMetrics(string label, NormalizedCoreCounterData counterData)
             {
-                float scalarFlops = counterData.pmc0;
-                float sseFlops = counterData.pmc1 * 2;
-                float avxFlops = counterData.pmc2 * 4;
+                float scalarFlops = counterData.pmc[0];
+                float sseFlops = counterData.pmc[1] * 2;
+                float avxFlops = counterData.pmc[2] * 4;
                 return new string[] { label,
                         FormatLargeNumber(counterData.activeCycles),
                         FormatLargeNumber(counterData.instr),
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         FormatLargeNumber(scalarFlops + sseFlops + avxFlops),
-                        string.Format("{0:F2}", (scalarFlops + sseFlops + avxFlops + counterData.pmc3) / counterData.activeCycles),
+                        string.Format("{0:F2}", (scalarFlops + sseFlops + avxFlops + counterData.pmc[3]) / counterData.activeCycles),
                         FormatLargeNumber(scalarFlops),
                         FormatLargeNumber(sseFlops),
                         FormatLargeNumber(avxFlops),
-                        string.Format("{0:F2}%", 100 * counterData.pmc3 / counterData.activeCycles)};
+                        string.Format("{0:F2}%", 100 * counterData.pmc[3] / counterData.activeCycles)};
             }
         }
 
@@ -678,10 +678,10 @@ namespace PmcReader.Intel
                         FormatLargeNumber(counterData.activeCycles),
                         FormatLargeNumber(counterData.instr),
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * counterData.pmc1 / counterData.pmc0),
-                        FormatLargeNumber(counterData.pmc1 * 64) + "B/s", 
-                        FormatLargeNumber(counterData.pmc2 * 64) + "B/s",
-                        FormatLargeNumber(counterData.pmc3 * 64) + "B/s"
+                        string.Format("{0:F2}%", 100 * counterData.pmc[1] / counterData.pmc[0]),
+                        FormatLargeNumber(counterData.pmc[1] * 64) + "B/s", 
+                        FormatLargeNumber(counterData.pmc[2] * 64) + "B/s",
+                        FormatLargeNumber(counterData.pmc[3] * 64) + "B/s"
                 };
             }
         }
@@ -746,12 +746,12 @@ namespace PmcReader.Intel
                         FormatLargeNumber(counterData.activeCycles),
                         FormatLargeNumber(counterData.instr),
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * counterData.pmc0 / counterData.instr),
-                        FormatLargeNumber(counterData.pmc0),
-                        FormatLargeNumber(counterData.pmc1),
-                        FormatLargeNumber(counterData.pmc2),
-                        FormatLargeNumber(counterData.pmc3),
-                        string.Format("{0:F2}", counterData.pmc0 / counterData.activeCycles)
+                        string.Format("{0:F2}%", 100 * counterData.pmc[0] / counterData.instr),
+                        FormatLargeNumber(counterData.pmc[0]),
+                        FormatLargeNumber(counterData.pmc[1]),
+                        FormatLargeNumber(counterData.pmc[2]),
+                        FormatLargeNumber(counterData.pmc[3]),
+                        string.Format("{0:F2}", counterData.pmc[0] / counterData.activeCycles)
                 };
             }
         }
@@ -811,18 +811,18 @@ namespace PmcReader.Intel
 
             private string[] computeMetrics(string label, NormalizedCoreCounterData counterData)
             {
-                float retUops = counterData.pmc0 - counterData.pmc1 + (counterData.pmc1 - counterData.pmc2) * 2 + (counterData.pmc2 - counterData.pmc3) * 3 + counterData.pmc3 * 4;
+                float retUops = counterData.pmc[0] - counterData.pmc[1] + (counterData.pmc[1] - counterData.pmc[2]) * 2 + (counterData.pmc[2] - counterData.pmc[3]) * 3 + counterData.pmc[3] * 4;
                 return new string[] { label,
                         FormatLargeNumber(counterData.activeCycles),
                         FormatLargeNumber(counterData.instr),
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2}%", 100 * retUops / (counterData.activeCycles * 4)),
                         string.Format("{0:F2}", retUops / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * counterData.pmc0 / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * (counterData.pmc0 - counterData.pmc1) / counterData.pmc0),
-                        string.Format("{0:F2}%", 100 * (counterData.pmc1 - counterData.pmc2) / counterData.pmc0),
-                        string.Format("{0:F2}%", 100 * (counterData.pmc2 - counterData.pmc3) / counterData.pmc0),
-                        string.Format("{0:F2}%", 100 * counterData.pmc3 / counterData.pmc0),
+                        string.Format("{0:F2}%", 100 * counterData.pmc[0] / counterData.activeCycles),
+                        string.Format("{0:F2}%", 100 * (counterData.pmc[0] - counterData.pmc[1]) / counterData.pmc[0]),
+                        string.Format("{0:F2}%", 100 * (counterData.pmc[1] - counterData.pmc[2]) / counterData.pmc[0]),
+                        string.Format("{0:F2}%", 100 * (counterData.pmc[2] - counterData.pmc[3]) / counterData.pmc[0]),
+                        string.Format("{0:F2}%", 100 * counterData.pmc[3] / counterData.pmc[0]),
                 };
             }
         }
@@ -887,12 +887,12 @@ namespace PmcReader.Intel
                         FormatLargeNumber(counterData.activeCycles),
                         FormatLargeNumber(counterData.instr),
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
-                        string.Format("{0:F2}", counterData.pmc0 / counterData.activeCycles),
-                        string.Format("{0:F2}", counterData.pmc0 / counterData.pmc1),
-                        string.Format("{0:F2}%", 100 * (counterData.activeCycles - counterData.pmc1) / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * (counterData.pmc1 - counterData.pmc2) / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * counterData.pmc2 / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * counterData.pmc3 / counterData.activeCycles)
+                        string.Format("{0:F2}", counterData.pmc[0] / counterData.activeCycles),
+                        string.Format("{0:F2}", counterData.pmc[0] / counterData.pmc[1]),
+                        string.Format("{0:F2}%", 100 * (counterData.activeCycles - counterData.pmc[1]) / counterData.activeCycles),
+                        string.Format("{0:F2}%", 100 * (counterData.pmc[1] - counterData.pmc[2]) / counterData.activeCycles),
+                        string.Format("{0:F2}%", 100 * counterData.pmc[2] / counterData.activeCycles),
+                        string.Format("{0:F2}%", 100 * counterData.pmc[3] / counterData.activeCycles)
                 };
             }
         }
@@ -957,13 +957,13 @@ namespace PmcReader.Intel
                         FormatLargeNumber(counterData.activeCycles),
                         FormatLargeNumber(counterData.instr),
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * counterData.pmc0 / (counterData.pmc1 + counterData.pmc0)),
-                        FormatLargeNumber(counterData.pmc0),
-                        string.Format("{0:F2}", counterData.pmc1 / counterData.instr * 1000),
-                        string.Format("{0:F2}", counterData.pmc2 / (counterData.pmc1 + counterData.pmc0)),
-                        string.Format("{0:F2}%", 100 * counterData.pmc3 / counterData.activeCycles),
-                        string.Format("{0:F2}", counterData.pmc2 / counterData.pmc3),
-                        FormatLargeNumber(counterData.pmc2)
+                        string.Format("{0:F2}%", 100 * counterData.pmc[0] / (counterData.pmc[1] + counterData.pmc[0])),
+                        FormatLargeNumber(counterData.pmc[0]),
+                        string.Format("{0:F2}", counterData.pmc[1] / counterData.instr * 1000),
+                        string.Format("{0:F2}", counterData.pmc[2] / (counterData.pmc[1] + counterData.pmc[0])),
+                        string.Format("{0:F2}%", 100 * counterData.pmc[3] / counterData.activeCycles),
+                        string.Format("{0:F2}", counterData.pmc[2] / counterData.pmc[3]),
+                        FormatLargeNumber(counterData.pmc[2])
                 };
             }
         }
@@ -1030,10 +1030,10 @@ namespace PmcReader.Intel
                         FormatLargeNumber(counterData.activeCycles),
                         FormatLargeNumber(counterData.instr),
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
-                        FormatLargeNumber(counterData.pmc0),
-                        FormatLargeNumber(counterData.pmc1),
-                        FormatLargeNumber(counterData.pmc2),
-                        FormatPercentage(counterData.pmc3, counterData.activeCycles)
+                        FormatLargeNumber(counterData.pmc[0]),
+                        FormatLargeNumber(counterData.pmc[1]),
+                        FormatLargeNumber(counterData.pmc[2]),
+                        FormatPercentage(counterData.pmc[3], counterData.activeCycles)
                 };
             }
         }

--- a/Intel/Skylake.cs
+++ b/Intel/Skylake.cs
@@ -122,10 +122,10 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        string.Format("{0:F2}", 1000 * counterData.pmc0 / counterData.instr),
-                        string.Format("{0:F2}", 1000 * counterData.pmc1 / counterData.instr),
-                        FormatPercentage(counterData.pmc2, counterData.activeCycles),
-                        FormatLargeNumber(counterData.pmc3)
+                        string.Format("{0:F2}", 1000 * counterData.pmc[0] / counterData.instr),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[1] / counterData.instr),
+                        FormatPercentage(counterData.pmc[2], counterData.activeCycles),
+                        FormatLargeNumber(counterData.pmc[3])
                 };
             }
         }
@@ -200,10 +200,10 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        string.Format("{0:F2}%", 100 * (counterData.pmc0 / counterData.instr)),
-                        string.Format("{0:F2}%", 100 * (counterData.pmc1 / counterData.instr)),
-                        string.Format("{0:F2}%", 100 * (counterData.pmc2 / counterData.instr)),
-                        string.Format("{0:F2}%", 100 * (counterData.pmc3 / counterData.instr)),
+                        string.Format("{0:F2}%", 100 * (counterData.pmc[0] / counterData.instr)),
+                        string.Format("{0:F2}%", 100 * (counterData.pmc[1] / counterData.instr)),
+                        string.Format("{0:F2}%", 100 * (counterData.pmc[2] / counterData.instr)),
+                        string.Format("{0:F2}%", 100 * (counterData.pmc[3] / counterData.instr)),
                 };
             }
         }
@@ -267,11 +267,11 @@ namespace PmcReader.Intel
                         FormatLargeNumber(counterData.activeCycles),
                         FormatLargeNumber(counterData.instr),
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * counterData.pmc0 / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * (counterData.pmc0 - counterData.pmc1) / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * (counterData.pmc1 - counterData.pmc2) / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * (counterData.pmc2 - counterData.pmc3) / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * counterData.pmc3 / counterData.activeCycles)
+                        string.Format("{0:F2}%", 100 * counterData.pmc[0] / counterData.activeCycles),
+                        string.Format("{0:F2}%", 100 * (counterData.pmc[0] - counterData.pmc[1]) / counterData.activeCycles),
+                        string.Format("{0:F2}%", 100 * (counterData.pmc[1] - counterData.pmc[2]) / counterData.activeCycles),
+                        string.Format("{0:F2}%", 100 * (counterData.pmc[2] - counterData.pmc[3]) / counterData.activeCycles),
+                        string.Format("{0:F2}%", 100 * counterData.pmc[3] / counterData.activeCycles)
                 };
             }
         }
@@ -344,10 +344,10 @@ namespace PmcReader.Intel
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * (counterData.pmc0 - counterData.pmc1) / counterData.pmc0),
-                        FormatLargeNumber((counterData.pmc0 - counterData.pmc1) * 64) + "B",
-                        FormatLargeNumber(counterData.pmc2 * 64) + "B",
-                        FormatLargeNumber(counterData.pmc3 * 64) + "B",
+                        string.Format("{0:F2}%", 100 * (counterData.pmc[0] - counterData.pmc[1]) / counterData.pmc[0]),
+                        FormatLargeNumber((counterData.pmc[0] - counterData.pmc[1]) * 64) + "B",
+                        FormatLargeNumber(counterData.pmc[2] * 64) + "B",
+                        FormatLargeNumber(counterData.pmc[3] * 64) + "B",
                 };
             }
         }
@@ -421,13 +421,13 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        string.Format("{0:F2}%", 100 * (1 - (counterData.pmc1 + counterData.pmc2 + counterData.pmc3)/counterData.pmc0)),
-                        string.Format("{0:F2}", 1000 * (counterData.pmc1 + counterData.pmc2 + counterData.pmc3)/counterData.instr),
-                        FormatLargeNumber(64 * counterData.pmc1) + "B/s",
-                        string.Format("{0:F2}", 1000 * (counterData.pmc2 + counterData.pmc3)/counterData.instr),
-                        FormatLargeNumber(64 * counterData.pmc2) + "B/s",
-                        string.Format("{0:F2}", 1000 * counterData.pmc3 / counterData.instr),
-                        FormatLargeNumber(64 * counterData.pmc3) + "B/s"
+                        string.Format("{0:F2}%", 100 * (1 - (counterData.pmc[1] + counterData.pmc[2] + counterData.pmc[3])/counterData.pmc[0])),
+                        string.Format("{0:F2}", 1000 * (counterData.pmc[1] + counterData.pmc[2] + counterData.pmc[3])/counterData.instr),
+                        FormatLargeNumber(64 * counterData.pmc[1]) + "B/s",
+                        string.Format("{0:F2}", 1000 * (counterData.pmc[2] + counterData.pmc[3])/counterData.instr),
+                        FormatLargeNumber(64 * counterData.pmc[2]) + "B/s",
+                        string.Format("{0:F2}", 1000 * counterData.pmc[3] / counterData.instr),
+                        FormatLargeNumber(64 * counterData.pmc[3]) + "B/s"
                 };
             }
         }
@@ -494,20 +494,20 @@ namespace PmcReader.Intel
 
             private string[] computeMetrics(string label, NormalizedCoreCounterData counterData, bool overall)
             {
-                float oneOp = counterData.pmc0 - counterData.pmc1;
-                float twoOps = counterData.pmc1 - counterData.pmc2;
-                float threeOps = counterData.pmc2 - counterData.pmc3;
-                float opCacheOps = oneOp + 2 * twoOps + 3 * threeOps + 4 * counterData.pmc3;
+                float oneOp = counterData.pmc[0] - counterData.pmc[1];
+                float twoOps = counterData.pmc[1] - counterData.pmc[2];
+                float threeOps = counterData.pmc[2] - counterData.pmc[3];
+                float opCacheOps = oneOp + 2 * twoOps + 3 * threeOps + 4 * counterData.pmc[3];
                 return new string[] { label,
                        FormatLargeNumber(counterData.activeCycles),
                        FormatLargeNumber(counterData.instr),
                        string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                        overall ? string.Format("{0:F2} W", counterData.packagePower) : "N/A",
                        overall ? FormatLargeNumber(counterData.instr / counterData.packagePower) : "N/A",
-                       FormatPercentage(counterData.pmc0, counterData.activeCycles),
-                       FormatPercentage(counterData.pmc1, counterData.activeCycles),
-                       FormatPercentage(counterData.pmc2, counterData.activeCycles),
-                       FormatPercentage(counterData.pmc3, counterData.activeCycles),
+                       FormatPercentage(counterData.pmc[0], counterData.activeCycles),
+                       FormatPercentage(counterData.pmc[1], counterData.activeCycles),
+                       FormatPercentage(counterData.pmc[2], counterData.activeCycles),
+                       FormatPercentage(counterData.pmc[3], counterData.activeCycles),
                 };
             }
         }
@@ -580,10 +580,10 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        string.Format("{0:F2}%", 100 * counterData.pmc0 / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * counterData.pmc1 / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * counterData.pmc2 / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * counterData.pmc3 / counterData.activeCycles)
+                        string.Format("{0:F2}%", 100 * counterData.pmc[0] / counterData.activeCycles),
+                        string.Format("{0:F2}%", 100 * counterData.pmc[1] / counterData.activeCycles),
+                        string.Format("{0:F2}%", 100 * counterData.pmc[2] / counterData.activeCycles),
+                        string.Format("{0:F2}%", 100 * counterData.pmc[3] / counterData.activeCycles)
                 };
             }
         }
@@ -656,10 +656,10 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        string.Format("{0:F2}%", 100 * counterData.pmc0 / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * counterData.pmc1 / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * counterData.pmc2 / counterData.activeCycles),
-                        string.Format("{0:F2}%", 100 * counterData.pmc3 / counterData.activeCycles)
+                        string.Format("{0:F2}%", 100 * counterData.pmc[0] / counterData.activeCycles),
+                        string.Format("{0:F2}%", 100 * counterData.pmc[1] / counterData.activeCycles),
+                        string.Format("{0:F2}%", 100 * counterData.pmc[2] / counterData.activeCycles),
+                        string.Format("{0:F2}%", 100 * counterData.pmc[3] / counterData.activeCycles)
                 };
             }
         }
@@ -732,10 +732,10 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        string.Format("{0:F2}%", 100 * counterData.pmc0 / (counterData.pmc0 + counterData.pmc1)),
-                        string.Format("{0:F2}", 1000 * counterData.pmc1 / counterData.instr),
-                        string.Format("{0:F2}", 1000 * (counterData.pmc2 + counterData.pmc3) / counterData.instr),
-                        string.Format("{0:F2}", 1000 * counterData.pmc3 / counterData.instr)
+                        string.Format("{0:F2}%", 100 * counterData.pmc[0] / (counterData.pmc[0] + counterData.pmc[1])),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[1] / counterData.instr),
+                        string.Format("{0:F2}", 1000 * (counterData.pmc[2] + counterData.pmc[3]) / counterData.instr),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[3] / counterData.instr)
                 };
             }
         }
@@ -801,10 +801,10 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        FormatPercentage(counterData.pmc0, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc2, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc3, counterData.activeCycles),
-                        FormatPercentage(counterData.pmc1, counterData.activeCycles)
+                        FormatPercentage(counterData.pmc[0], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[2], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[3], counterData.activeCycles),
+                        FormatPercentage(counterData.pmc[1], counterData.activeCycles)
                 };
             }
         }
@@ -869,9 +869,9 @@ namespace PmcReader.Intel
 
             private string[] computeMetrics(string label, NormalizedCoreCounterData counterData)
             {
-                float scalarFlops = counterData.pmc0;
-                float flops128b = counterData.pmc1 * 4;
-                float flops256b = counterData.pmc2 * 8;
+                float scalarFlops = counterData.pmc[0];
+                float flops128b = counterData.pmc[1] * 4;
+                float flops256b = counterData.pmc[2] * 8;
                 float totalFlops = scalarFlops + flops128b + flops256b;
                 return new string[] { label,
                         FormatLargeNumber(counterData.activeCycles),
@@ -883,9 +883,9 @@ namespace PmcReader.Intel
                         FormatLargeNumber(scalarFlops),
                         FormatLargeNumber(flops128b),
                         FormatLargeNumber(flops256b),
-                        FormatLargeNumber(counterData.pmc3),
+                        FormatLargeNumber(counterData.pmc[3]),
                         string.Format("{0:F2}", totalFlops / counterData.activeCycles),
-                        FormatPercentage(counterData.pmc3, counterData.instr)
+                        FormatPercentage(counterData.pmc[3], counterData.instr)
                 };
             }
         }
@@ -950,9 +950,9 @@ namespace PmcReader.Intel
 
             private string[] computeMetrics(string label, NormalizedCoreCounterData counterData)
             {
-                float scalarFlops = counterData.pmc0;
-                float flops128b = counterData.pmc1 * 2;
-                float flops256b = counterData.pmc2 * 4;
+                float scalarFlops = counterData.pmc[0];
+                float flops128b = counterData.pmc[1] * 2;
+                float flops256b = counterData.pmc[2] * 4;
                 float totalFlops = scalarFlops + flops128b + flops256b;
                 return new string[] { label,
                         FormatLargeNumber(counterData.activeCycles),
@@ -964,9 +964,9 @@ namespace PmcReader.Intel
                         FormatLargeNumber(scalarFlops),
                         FormatLargeNumber(flops128b),
                         FormatLargeNumber(flops256b),
-                        FormatLargeNumber(counterData.pmc3),
+                        FormatLargeNumber(counterData.pmc[3]),
                         string.Format("{0:F2}", totalFlops / counterData.activeCycles),
-                        FormatPercentage(counterData.pmc3, counterData.instr)
+                        FormatPercentage(counterData.pmc[3], counterData.instr)
                 };
             }
         }
@@ -1032,12 +1032,12 @@ namespace PmcReader.Intel
                         string.Format("{0:F2}", counterData.instr / counterData.activeCycles),
                         string.Format("{0:F2} W", counterData.packagePower),
                         FormatLargeNumber(counterData.instr / counterData.packagePower),
-                        FormatLargeNumber(counterData.pmc0),
-                        string.Format("{0:F2}", 1000 * counterData.pmc1 / counterData.instr),
-                        FormatLargeNumber(counterData.pmc1),
-                        FormatLargeNumber(counterData.pmc2),
-                        FormatLargeNumber(counterData.pmc3),
-                        string.Format("{0:F2}", 1000 * counterData.pmc3 / counterData.instr),
+                        FormatLargeNumber(counterData.pmc[0]),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[1] / counterData.instr),
+                        FormatLargeNumber(counterData.pmc[1]),
+                        FormatLargeNumber(counterData.pmc[2]),
+                        FormatLargeNumber(counterData.pmc[3]),
+                        string.Format("{0:F2}", 1000 * counterData.pmc[3] / counterData.instr),
                 };
             }
         }


### PR DESCRIPTION
…o we can support hardware that has different numbers of general counters (e.g. ADL has 6 or 8 depending on the core type).

This is the start to enable pushing the different core types into the ModernIntelCpu base class so that the hybrid model isn't fundamentally different than the basic models.