### PR TITLE
Fix L1 instruction and OP cache mixup in the Zen 4 Instruction Fetch view.

### DIFF
--- a/AMD/Zen4.cs
+++ b/AMD/Zen4.cs
@@ -522,10 +522,10 @@ namespace PmcReader.AMD
 
             public void Initialize()
             {
-                cpu.ProgramPerfCounters(GetPerfCtlValue(0x8E, 0x1F, true, true, false, false, true, false, 0, 0x1, false, false), // IC access
-                    GetPerfCtlValue(0x8E, 0x18, true, true, false, false, true, false, 0, 0x1, false, false),  // IC Miss
-                    GetPerfCtlValue(0x8F, 0x7, true, true, false, false, true, false, 0, 0x2, false, false),  // OC Access
+                cpu.ProgramPerfCounters(GetPerfCtlValue(0x8F, 0x7, true, true, false, false, true, false, 0, 0x2, false, false),  // OC Access
                     GetPerfCtlValue(0x8F, 0x4, true, true, false, false, true, false, 0, 0x2, false, false),  // OC Miss
+                    GetPerfCtlValue(0x8E, 0x1F, true, true, false, false, true, false, 0, 0x1, false, false), // IC access
+                    GetPerfCtlValue(0x8E, 0x18, true, true, false, false, true, false, 0, 0x1, false, false),  // IC Miss
                     GetPerfCtlValue(0x84, 0, true, true, false, false, true, false, 0, 0, false, false),  // iTLB miss, L2 iTLB hit
                     GetPerfCtlValue(0x85, 0xF, true, true, false, false, true, false, 0, 0, false, false)); // L2 iTLB miss (page walk)
             }


### PR DESCRIPTION
Disabling the OP cache now shows 0% for Op$ Hitrate instead of L1i Hitrate.

Before:
![Before (Op$ Enabled)](https://github.com/user-attachments/assets/a9f3cb99-1183-49b3-83ca-cce56cd75b29)
![Before (Op$ Disabled)](https://github.com/user-attachments/assets/0af2e58a-0f6c-471f-8dd1-70ebf9c248bb)

After:
![After (Op$ Enabled)](https://github.com/user-attachments/assets/361b764e-9c8a-4e7d-827a-6829a1cd877b)
![After (Op$ Disabled)](https://github.com/user-attachments/assets/f9ff17f5-5919-46b5-a77f-7bc0d98aaacf)